### PR TITLE
Add all-user flag to sacct queries by default

### DIFF
--- a/src/slurm_waiting_times/sacct.py
+++ b/src/slurm_waiting_times/sacct.py
@@ -38,11 +38,13 @@ def build_sacct_command(
         end.strftime("%Y-%m-%dT%H:%M:%S"),
     ]
 
-    if not include_steps:
-        command.append("-X")
-
     if users:
         command.extend(["--user", ",".join(users)])
+    else:
+        command.append("-a")
+
+    if not include_steps:
+        command.append("-X")
 
     if partitions:
         command.extend(["--partition", ",".join(partitions)])

--- a/tests/test_sacct.py
+++ b/tests/test_sacct.py
@@ -1,4 +1,6 @@
-from slurm_waiting_times.sacct import parse_sacct_output
+from datetime import datetime
+
+from slurm_waiting_times.sacct import build_sacct_command, parse_sacct_output
 
 
 def test_parse_sacct_output_skips_invalid_rows():
@@ -22,3 +24,23 @@ def test_parse_sacct_output_warns_on_bad_timestamp(caplog):
         rows = parse_sacct_output(bad_output, timezone="UTC")
     assert rows == []
     assert "timestamp error" in caplog.text
+
+
+def test_build_sacct_command_includes_all_users_flag_by_default():
+    start = datetime(2025, 9, 15)
+    end = datetime(2025, 9, 22)
+
+    command = build_sacct_command(start, end)
+
+    assert "-a" in command
+    assert "--user" not in command
+
+
+def test_build_sacct_command_uses_specific_users_when_requested():
+    start = datetime(2025, 9, 15)
+    end = datetime(2025, 9, 22)
+
+    command = build_sacct_command(start, end, users=["alice", "bob"])
+
+    assert "-a" not in command
+    assert command[command.index("--user") + 1] == "alice,bob"


### PR DESCRIPTION
## Summary
- default sacct command now requests data for all users when no explicit filter is provided
- add regression tests to cover both the default and user-filtered command variants

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6647250a08325bbdb116ccc991eb7