### PR TITLE
Format histogram time labels as d-hh:mm

### DIFF
--- a/src/slurm_waiting_times/histogram.py
+++ b/src/slurm_waiting_times/histogram.py
@@ -61,33 +61,16 @@ _NICE_TIME_SECONDS = [
 
 
 def _format_time_value(total_seconds: float) -> str:
-    if total_seconds < 1:
-        milliseconds = total_seconds * 1000
-        if milliseconds < 1:
-            microseconds = milliseconds * 1000
-            return f"{microseconds:.0f} µs"
-        return f"{milliseconds:.0f} ms"
-    if total_seconds < 60:
-        return f"{total_seconds:.0f} s"
-    minutes = total_seconds / 60
-    if minutes < 60:
-        if minutes.is_integer():
-            return f"{minutes:.0f} min"
-        return f"{minutes:.1f} min"
-    hours = minutes / 60
-    if hours < 24:
-        if hours.is_integer():
-            return f"{hours:.0f} h"
-        return f"{hours:.1f} h"
-    days = hours / 24
-    if days < 7:
-        if days.is_integer():
-            return f"{days:.0f} d"
-        return f"{days:.1f} d"
-    weeks = days / 7
-    if weeks.is_integer():
-        return f"{weeks:.0f} wk"
-    return f"{weeks:.1f} wk"
+    total_minutes = int(math.floor(total_seconds / 60 + 0.5))
+    if total_minutes < 0:
+        total_minutes = 0
+
+    days, remainder_minutes = divmod(total_minutes, 24 * 60)
+    hours, minutes = divmod(remainder_minutes, 60)
+
+    if days >= 1:
+        return f"{days}-{hours:02d}:{minutes:02d}"
+    return f"{hours:02d}:{minutes:02d}"
 
 
 def _nice_ticks(min_value: float, max_value: float, *, use_seconds: bool) -> list[float]:

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -5,7 +5,11 @@ import pytest
 pytest.importorskip("matplotlib")
 from matplotlib import pyplot as plt
 
-from slurm_waiting_times.histogram import create_histogram, prepare_histogram_values
+from slurm_waiting_times.histogram import (
+    _format_time_value,
+    create_histogram,
+    prepare_histogram_values,
+)
 from slurm_waiting_times.models import JobRecord
 
 
@@ -44,3 +48,14 @@ def test_create_histogram_draws_mean_line():
     assert "Mean wait" in line.get_label()
     fig.clf()
     plt.close(fig)
+
+
+def test_format_time_value_rounds_to_minutes():
+    # 89 seconds should round down, while 90 rounds up
+    assert _format_time_value(89) == "00:01"
+    assert _format_time_value(90) == "00:02"
+
+
+def test_format_time_value_includes_days():
+    total_seconds = (1 * 24 * 60 + 2 * 60 + 30) * 60
+    assert _format_time_value(total_seconds) == "1-02:30"


### PR DESCRIPTION
## Summary
- update the histogram tick formatter to render durations in d-hh:mm or hh:mm format with rounding to the nearest minute
- add unit tests that cover rounding behaviour and day-inclusive formatting for histogram labels

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68d67417b4e48325b9ffafc3da3d2448