### PR TITLE
Format durations without seconds and stabilise histogram ticks

### DIFF
--- a/src/slurm_waiting_times/histogram.py
+++ b/src/slurm_waiting_times/histogram.py
@@ -61,16 +61,7 @@ _NICE_TIME_SECONDS = [
 
 
 def _format_time_value(total_seconds: float) -> str:
-    total_minutes = int(math.floor(total_seconds / 60 + 0.5))
-    if total_minutes < 0:
-        total_minutes = 0
-
-    days, remainder_minutes = divmod(total_minutes, 24 * 60)
-    hours, minutes = divmod(remainder_minutes, 60)
-
-    if days >= 1:
-        return f"{days}-{hours:02d}:{minutes:02d}"
-    return f"{hours:02d}:{minutes:02d}"
+    return format_timedelta_hms(total_seconds)
 
 
 def _nice_ticks(min_value: float, max_value: float, *, use_seconds: bool) -> list[float]:
@@ -225,8 +216,9 @@ def create_histogram(
         ax.set_xscale("log")
         ticks = _nice_ticks(min(axis_values), max(axis_values), use_seconds=use_seconds)
         if ticks:
-            ax.set_xticks(ticks)
+            ax.xaxis.set_major_locator(ticker.FixedLocator(ticks))
         ax.xaxis.set_major_formatter(formatter)
+        ax.xaxis.get_offset_text().set_visible(False)
         ax.tick_params(axis="x", labelsize=11, colors="#303030", rotation=25)
         plt.setp(ax.get_xticklabels(), ha="right")
         ax.tick_params(axis="y", labelsize=11, colors="#303030")

--- a/src/slurm_waiting_times/time_utils.py
+++ b/src/slurm_waiting_times/time_utils.py
@@ -80,10 +80,18 @@ def parse_cli_datetime(value: str | None, default: datetime, tzinfo: ZoneInfo) -
 
 
 def format_timedelta_hms(seconds: float) -> str:
-    total_seconds = int(round(seconds))
-    hours, remainder = divmod(total_seconds, 3600)
-    minutes, secs = divmod(remainder, 60)
-    return f"{hours:02d}:{minutes:02d}:{secs:02d}"
+    """Format ``seconds`` as a human readable duration without seconds."""
+
+    total_minutes = int(math.floor(seconds / 60.0 + 0.5))
+    if total_minutes < 0:
+        total_minutes = 0
+
+    days, remainder_minutes = divmod(total_minutes, 24 * 60)
+    hours, minutes = divmod(remainder_minutes, 60)
+
+    if days >= 1:
+        return f"{days}-{hours:02d}:{minutes:02d}"
+    return f"{hours:02d}:{minutes:02d}"
 
 
 def freedman_diaconis_bins(values: Iterable[float]) -> int:

--- a/tests/test_time_utils.py
+++ b/tests/test_time_utils.py
@@ -1,5 +1,4 @@
 import pytest
-import pytest
 from zoneinfo import ZoneInfo
 
 from slurm_waiting_times.time_utils import (
@@ -32,7 +31,17 @@ def test_parse_datetime_accepts_multiple_formats(value):
     dt = parse_datetime(value, tz)
     assert dt.year == 2024
     assert dt.tzinfo == tz
-
-
-def test_format_timedelta_hms():
-    assert format_timedelta_hms(3661) == "01:01:01"
+@pytest.mark.parametrize(
+    "seconds, expected",
+    [
+        (0, "00:00"),
+        (29, "00:00"),
+        (30, "00:01"),
+        (89, "00:01"),
+        (90, "00:02"),
+        (3661, "01:01"),
+        ((24 * 60 * 60) + (2 * 60 * 60) + (30 * 60), "1-02:30"),
+    ],
+)
+def test_format_timedelta_hms(seconds, expected):
+    assert format_timedelta_hms(seconds) == expected


### PR DESCRIPTION
## Summary
- format duration displays without seconds, showing day-hour:minute when needed
- reuse the new formatter for histogram ticks and hide scientific offsets on log axes

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68d67745e3d88325a62959116d7ed16a