### PR TITLE
Support month-only CLI date arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ slurm-waiting-times [--start <time>] [--end <time>] [--user <list>] [--partition
 ```
 
 * `--start` / `--end`: ISO or Slurm-style datetimes. Defaults to the last 14 days ending “now”.
+  Supplying a year and month (e.g. `2025-09`) expands to the first or last day of
+  that month as appropriate, allowing quick whole-month reports.
 * `--user`: comma-separated users to include. Array-task IDs (e.g. `12345_7`) are kept, job steps (`12345.batch`) are dropped unless `--include-steps` is present.
 * `--partition`: comma-separated list of partitions; shell-style wildcards are accepted.
 * `--tz`: interpret timestamps in the supplied IANA timezone (defaults to the local system zone).

--- a/src/slurm_waiting_times/cli.py
+++ b/src/slurm_waiting_times/cli.py
@@ -15,7 +15,7 @@ from .sacct import SacctError, build_sacct_command, parse_sacct_output, run_sacc
 from .time_utils import (
     ensure_timezone,
     format_timedelta_hms,
-    parse_cli_datetime,
+    parse_cli_datetime_window,
 )
 
 LOGGER = logging.getLogger(__name__)
@@ -170,8 +170,13 @@ def main(argv: Sequence[str] | None = None) -> int:
     default_start = now - timedelta(days=DEFAULT_WINDOW_DAYS)
 
     try:
-        start_dt = parse_cli_datetime(args.start, default_start, tzinfo)
-        end_dt = parse_cli_datetime(args.end, default_end, tzinfo)
+        start_dt, end_dt = parse_cli_datetime_window(
+            args.start,
+            args.end,
+            default_start,
+            default_end,
+            tzinfo,
+        )
     except ValueError as exc:
         print(f"Error parsing date: {exc}", file=sys.stderr)
         return 2


### PR DESCRIPTION
## Summary
- add month-aware parsing for CLI start and end arguments
- infer whole-month windows when users provide year-month values without days
- document the new behaviour and cover it with unit tests

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd6aab3d58832597e824f783b216da