### PR TITLE
Adjust histogram labels and output filenames

### DIFF
--- a/src/slurm_waiting_times/histogram.py
+++ b/src/slurm_waiting_times/histogram.py
@@ -185,7 +185,7 @@ def create_histogram(
         xlabel = "Waiting time [seconds]"
         mean_line_value = mean_seconds
     else:
-        xlabel = "Waiting time [minutes]"
+        xlabel = "Waiting time"
         mean_line_value = mean_seconds / 60.0
 
     def tick_formatter(value: float, pos: int) -> str:  # pragma: no cover - simple formatting

--- a/src/slurm_waiting_times/output.py
+++ b/src/slurm_waiting_times/output.py
@@ -23,17 +23,16 @@ def compact_args(tokens: Sequence[str]) -> str | None:
 
     joined = "_".join(token.replace(" ", "_") for token in tokens)
     sanitised = _SANITIZE_RE.sub("_", joined)
-    if len(sanitised) > 40:
-        sanitised = sanitised[:40]
+    if len(sanitised) > 80:
+        sanitised = sanitised[:80]
     return sanitised
 
 
 def build_prefix(now: datetime, tokens: Sequence[str]) -> str:
-    timestamp = now.strftime("%Y-%m-%d_%H:%M")
     args_part = compact_args(tokens)
     if args_part:
-        return f"{timestamp}-{args_part}"
-    return timestamp
+        return args_part
+    return now.strftime("%Y-%m-%d")
 
 
 def results_csv_path(prefix: str) -> Path:

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -41,7 +41,7 @@ def test_create_histogram_draws_mean_line():
     records = [make_record(5), make_record(15)]
     fig = create_histogram(records, use_seconds=False, bins=2, title="Example")
     ax = fig.axes[0]
-    assert ax.get_xlabel() == "Waiting time [minutes]"
+    assert ax.get_xlabel() == "Waiting time"
     assert ax.lines, "Expected a mean line"
     line = ax.lines[0]
     assert pytest.approx(line.get_xdata()[0], rel=1e-6) == 10.0

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -10,7 +10,13 @@ def test_compact_args_sanitises_and_truncates():
     assert "*" not in compact
 
 
-def test_build_prefix_includes_timestamp():
+def test_build_prefix_uses_tokens_without_timestamp():
     now = datetime(2024, 5, 1, 12, 30)
-    prefix = build_prefix(now, ["start=20240501"])
-    assert prefix.startswith("2024-05-01_12:30-start=20240501")
+    prefix = build_prefix(now, ["start=2024-05-01", "user=all"])
+    assert prefix == "start=2024-05-01_user=all"
+
+
+def test_build_prefix_falls_back_to_date():
+    now = datetime(2024, 5, 1, 12, 30)
+    prefix = build_prefix(now, [])
+    assert prefix == "2024-05-01"


### PR DESCRIPTION
## Summary
- remove the "top-level jobs" hint from generated histogram titles and simplify the default X-axis label
- include an explicit user token (defaulting to "all"), improve datetime formatting, and drop the timestamp from output file prefixes
- lengthen the compact argument limit and refresh unit tests for the new behaviours

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd6bfcc0908325be0bfa3d930c8945