### PR TITLE
Ensure default end date appears in output filenames

### DIFF
--- a/tests/test_cli_tokens.py
+++ b/tests/test_cli_tokens.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+
+from slurm_waiting_times.cli import _args_tokens
+
+
+def test_args_tokens_include_end_token_when_not_explicitly_supplied():
+    tokens = _args_tokens(
+        start_supplied=True,
+        start_value=datetime(2025, 3, 1),
+        end_value=datetime(2025, 3, 31),
+        users=None,
+        partitions=None,
+        include_steps=False,
+        tz=None,
+        bins=None,
+        bin_seconds=False,
+        max_wait_hours=None,
+    )
+
+    assert tokens[0] == "start=2025-03-01"
+    assert tokens[1] == "end=2025-03-31"

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -12,8 +12,15 @@ def test_compact_args_sanitises_and_truncates():
 
 def test_build_prefix_uses_tokens_without_timestamp():
     now = datetime(2024, 5, 1, 12, 30)
-    prefix = build_prefix(now, ["start=2024-05-01", "user=all"])
-    assert prefix == "start=2024-05-01_user=all"
+    prefix = build_prefix(
+        now,
+        [
+            "start=2024-05-01",
+            "end=2024-05-31",
+            "user=all",
+        ],
+    )
+    assert prefix == "start=2024-05-01_end=2024-05-31_user=all"
 
 
 def test_build_prefix_falls_back_to_date():


### PR DESCRIPTION
## Summary
- update the output prefix test to expect the end date token in generated filenames
- add a CLI token unit test to confirm the end date is always inserted when building prefixes

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd6f086a1c83259aa6cf94eb49b9ca