### PR TITLE
Adjust waiting times title formatting

### DIFF
--- a/src/slurm_waiting_times/cli.py
+++ b/src/slurm_waiting_times/cli.py
@@ -148,11 +148,14 @@ def _title(
 ) -> str:
     user_summary = ",".join(users) if users else "all users"
     partition_summary = ",".join(partitions) if partitions else "all partitions"
-    steps_summary = "steps included" if include_steps else "steps excluded"
+    steps_summary = "steps included" if include_steps else None
+    details = [user_summary, partition_summary]
+    if steps_summary:
+        details.append(steps_summary)
     return (
         "Waiting times "
         f"{start.strftime('%Y-%m-%d')} → {end.strftime('%Y-%m-%d')} "
-        f"({user_summary}; {partition_summary}; {steps_summary})"
+        f"({'; '.join(details)})"
     )
 
 


### PR DESCRIPTION
## Summary
- stop appending "steps excluded" to waiting times titles when steps are not included
- keep the "steps included" indicator when the report includes steps

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'slurm_waiting_times')*

------
https://chatgpt.com/codex/tasks/task_e_68dd715560508325bf2a638fbca53a9e