### PR TITLE
Add job type filtering and classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ uv pip install -e .
 ```text
 slurm-waiting-times [--start <time>] [--end <time>] [--user <list>] [--partition <list>] \
                     [--include-steps] [--tz <zone>] [--bins <n>] [--bin-seconds] \
-                    [--max-wait-hours <hours>] [--dry-run]
+                    [--max-wait-hours <hours>] [--job-type <kind>] [--dry-run]
 ```
 
 * `--start` / `--end`: ISO or Slurm-style datetimes. Defaults to the last 14 days ending “now”.
@@ -29,6 +29,7 @@ slurm-waiting-times [--start <time>] [--end <time>] [--user <list>] [--partition
   that month as appropriate, allowing quick whole-month reports.
 * `--user`: comma-separated users to include. Array-task IDs (e.g. `12345_7`) are kept, job steps (`12345.batch`) are dropped unless `--include-steps` is present.
 * `--partition`: comma-separated list of partitions; shell-style wildcards are accepted.
+* `--job-type`: restrict results to `cpu-only`, `1-gpu`, `single-node`, or `multi-node` jobs.
 * `--tz`: interpret timestamps in the supplied IANA timezone (defaults to the local system zone).
 * `--bins`: override the Freedman–Diaconis bin selection.
 * `--bin-seconds`: express waiting times in seconds rather than minutes on the histogram X-axis.
@@ -52,7 +53,7 @@ slurm-waiting-times --user alice,bob --partition mcml-a100,mcml-h100
 
 ## Output interpretation
 
-The CSV file contains job metadata plus a `WaitSeconds` column. The histogram uses minutes by default, adds a dashed red line at the mean waiting time, and includes a legend annotation. All timestamps are normalised to the selected timezone.
+The CSV file contains job metadata plus `Nodes`, `AllocGRES`, `JobType`, and a `WaitSeconds` column. The histogram uses minutes by default, adds a dashed red line at the mean waiting time, and includes a legend annotation. All timestamps are normalised to the selected timezone.
 
 To inspect a histogram, run the CLI with your desired arguments and open the generated PNG in the `output/` directory.
 

--- a/src/slurm_waiting_times/cli.py
+++ b/src/slurm_waiting_times/cli.py
@@ -48,6 +48,11 @@ def parse_arguments(argv: Sequence[str] | None = None) -> argparse.Namespace:
         help="Comma-separated list of partitions to include. Wildcards are supported.",
     )
     parser.add_argument(
+        "--job-type",
+        choices=["cpu-only", "1-gpu", "single-node", "multi-node"],
+        help="Restrict results to a specific job type derived from sacct metadata.",
+    )
+    parser.add_argument(
         "--include-steps",
         action="store_true",
         help="Include job steps such as .batch and .extern entries.",
@@ -115,6 +120,7 @@ def _args_tokens(
     bins: int | None,
     bin_seconds: bool,
     max_wait_hours: float | None,
+    job_type: str | None,
 ) -> list[str]:
     tokens: list[str] = []
     if start_supplied:
@@ -128,6 +134,8 @@ def _args_tokens(
         tokens.append(f"partition={','.join(partitions)}")
     if include_steps:
         tokens.append("steps")
+    if job_type:
+        tokens.append(f"jobtype={job_type}")
     # Timezone is intentionally omitted from the filename prefix for clarity.
     if bins is not None:
         tokens.append(f"bins={bins}")
@@ -224,6 +232,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         include_steps=args.include_steps,
         user_filters=users,
         partition_filters=partitions,
+        job_type=args.job_type,
         max_wait_hours=max_wait,
     )
 
@@ -249,6 +258,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         bins=bins,
         bin_seconds=args.bin_seconds,
         max_wait_hours=max_wait,
+        job_type=args.job_type,
     )
     prefix = build_prefix(now, tokens)
 

--- a/src/slurm_waiting_times/models.py
+++ b/src/slurm_waiting_times/models.py
@@ -14,6 +14,8 @@ class SacctRow:
     start_time: datetime
     state: str
     partition: str
+    nodes: int | None
+    alloc_gres: str | None
 
 
 @dataclass(slots=True)
@@ -21,3 +23,4 @@ class JobRecord(SacctRow):
     """A sacct row augmented with waiting-time metadata."""
 
     wait_seconds: float
+    job_type: str | None = None

--- a/src/slurm_waiting_times/output.py
+++ b/src/slurm_waiting_times/output.py
@@ -54,6 +54,9 @@ def write_results_csv(path: Path, records: Iterable[JobRecord]) -> None:
                 "Start",
                 "State",
                 "Partition",
+                "Nodes",
+                "AllocGRES",
+                "JobType",
                 "WaitSeconds",
             ]
         )
@@ -66,6 +69,9 @@ def write_results_csv(path: Path, records: Iterable[JobRecord]) -> None:
                     record.start_time.isoformat(),
                     record.state,
                     record.partition,
+                    "" if record.nodes is None else record.nodes,
+                    record.alloc_gres or "",
+                    record.job_type or "",
                     f"{record.wait_seconds:.2f}",
                 ]
             )

--- a/src/slurm_waiting_times/processing.py
+++ b/src/slurm_waiting_times/processing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import fnmatch
+import re
 from typing import Iterable, List, Sequence
 
 from .models import JobRecord, SacctRow
@@ -10,12 +11,46 @@ def _matches(value: str, patterns: Sequence[str]) -> bool:
     return any(fnmatch.fnmatch(value, pattern) for pattern in patterns)
 
 
+_GPU_PATTERN = re.compile(r"gpu(?::[^,()]+)*:(\d+)", flags=re.IGNORECASE)
+
+
+def _count_gpus(alloc_gres: str | None) -> int:
+    if not alloc_gres:
+        return 0
+
+    cleaned = re.sub(r"\([^)]*\)", "", alloc_gres)
+    matches = _GPU_PATTERN.findall(cleaned)
+    return sum(int(match) for match in matches)
+
+
+def determine_job_type(row: SacctRow) -> str | None:
+    """Infer the job type from sacct metadata."""
+
+    nodes = row.nodes
+    gpu_count = _count_gpus(row.alloc_gres)
+
+    if nodes is not None and nodes > 1:
+        return "multi-node"
+
+    if gpu_count == 0:
+        return "cpu-only"
+
+    if gpu_count == 1:
+        return "1-gpu"
+
+    if nodes == 1 or nodes is None:
+        return "single-node"
+
+    return None
+
+
 def filter_rows(
     rows: Iterable[SacctRow],
     *,
     include_steps: bool = False,
     user_filters: Sequence[str] | None = None,
     partition_filters: Sequence[str] | None = None,
+    job_type: str | None = None,
     max_wait_hours: float | None = None,
 ) -> List[JobRecord]:
     filtered: List[JobRecord] = []
@@ -33,6 +68,11 @@ def filter_rows(
 
         wait_seconds = (row.start_time - row.submit_time).total_seconds()
 
+        row_job_type = determine_job_type(row)
+
+        if job_type and row_job_type != job_type:
+            continue
+
         if wait_cap is not None and wait_seconds > wait_cap:
             continue
 
@@ -44,7 +84,10 @@ def filter_rows(
                 start_time=row.start_time,
                 state=row.state,
                 partition=row.partition,
+                nodes=row.nodes,
+                alloc_gres=row.alloc_gres,
                 wait_seconds=wait_seconds,
+                job_type=row_job_type,
             )
         )
 

--- a/tests/test_cli_tokens.py
+++ b/tests/test_cli_tokens.py
@@ -15,7 +15,26 @@ def test_args_tokens_include_end_token_when_not_explicitly_supplied():
         bins=None,
         bin_seconds=False,
         max_wait_hours=None,
+        job_type=None,
     )
 
     assert tokens[0] == "start=2025-03-01"
     assert tokens[1] == "end=2025-03-31"
+
+
+def test_args_tokens_include_job_type_when_requested():
+    tokens = _args_tokens(
+        start_supplied=False,
+        start_value=datetime(2025, 3, 1),
+        end_value=datetime(2025, 3, 31),
+        users=None,
+        partitions=None,
+        include_steps=False,
+        tz=None,
+        bins=None,
+        bin_seconds=False,
+        max_wait_hours=None,
+        job_type="multi-node",
+    )
+
+    assert "jobtype=multi-node" in tokens

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -27,6 +27,8 @@ def make_record(wait_minutes: float) -> JobRecord:
         start_time=start,
         state="COMPLETED",
         partition="gpu",
+        nodes=1,
+        alloc_gres=None,
         wait_seconds=wait_seconds,
     )
 

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1,13 +1,22 @@
 from datetime import datetime, timedelta, timezone
 
 from slurm_waiting_times.models import SacctRow
-from slurm_waiting_times.processing import filter_rows
+from slurm_waiting_times.processing import determine_job_type, filter_rows
 
 
 TZ = timezone.utc
 
 
-def make_row(job_id: str, submit_offset: int, start_offset: int, *, user: str = "alice", partition: str = "gpu") -> SacctRow:
+def make_row(
+    job_id: str,
+    submit_offset: int,
+    start_offset: int,
+    *,
+    user: str = "alice",
+    partition: str = "gpu",
+    nodes: int | None = 1,
+    alloc_gres: str | None = "gpu:1",
+) -> SacctRow:
     submit = datetime(2024, 5, 1, 12, 0, tzinfo=TZ) + timedelta(minutes=submit_offset)
     start = datetime(2024, 5, 1, 12, 0, tzinfo=TZ) + timedelta(minutes=start_offset)
     return SacctRow(
@@ -17,15 +26,17 @@ def make_row(job_id: str, submit_offset: int, start_offset: int, *, user: str = 
         start_time=start,
         state="COMPLETED",
         partition=partition,
+        nodes=nodes,
+        alloc_gres=alloc_gres,
     )
 
 
 def test_filter_rows_excludes_steps_and_filters_users_partitions():
     rows = [
-        make_row("123", 0, 10, user="alice", partition="gpu-a"),
-        make_row("123.batch", 0, 10, user="alice", partition="gpu-a"),
-        make_row("456", 0, 5, user="bob", partition="gpu-b"),
-        make_row("789", 0, 15, user="carol", partition="cpu"),
+        make_row("123", 0, 10, user="alice", partition="gpu-a", nodes=1, alloc_gres="gpu:1"),
+        make_row("123.batch", 0, 10, user="alice", partition="gpu-a", nodes=1, alloc_gres="gpu:1"),
+        make_row("456", 0, 5, user="bob", partition="gpu-b", nodes=1, alloc_gres="gpu:1"),
+        make_row("789", 0, 15, user="carol", partition="cpu", nodes=1, alloc_gres=None),
     ]
 
     filtered = filter_rows(
@@ -48,3 +59,30 @@ def test_filter_rows_max_wait_hours():
 
     filtered = filter_rows(rows, max_wait_hours=1)
     assert [record.job_id for record in filtered] == ["123"]
+
+
+def test_determine_job_type_infers_expected_categories():
+    cpu_row = make_row("1", 0, 5, alloc_gres=None)
+    assert determine_job_type(cpu_row) == "cpu-only"
+
+    single_gpu_row = make_row("2", 0, 5, alloc_gres="gpu:1")
+    assert determine_job_type(single_gpu_row) == "1-gpu"
+
+    multi_gpu_row = make_row("3", 0, 5, alloc_gres="gpu:tesla:4", nodes=1)
+    assert determine_job_type(multi_gpu_row) == "single-node"
+
+    multi_node_row = make_row("4", 0, 5, alloc_gres="gpu:4", nodes=2)
+    assert determine_job_type(multi_node_row) == "multi-node"
+
+
+def test_filter_rows_supports_job_type_filter():
+    rows = [
+        make_row("cpu", 0, 5, alloc_gres=None),
+        make_row("one-gpu", 0, 5, alloc_gres="gpu:1"),
+        make_row("multi-gpu", 0, 5, alloc_gres="gpu:4", nodes=1),
+        make_row("multi-node", 0, 5, alloc_gres="gpu:1", nodes=3),
+    ]
+
+    filtered = filter_rows(rows, job_type="1-gpu")
+    assert [record.job_id for record in filtered] == ["one-gpu"]
+    assert filtered[0].job_type == "1-gpu"

--- a/tests/test_sacct.py
+++ b/tests/test_sacct.py
@@ -5,9 +5,9 @@ from slurm_waiting_times.sacct import build_sacct_command, parse_sacct_output
 
 def test_parse_sacct_output_skips_invalid_rows():
     output = """
-123|alice|2024-05-01T10:00:00|2024-05-01T10:05:00|COMPLETED|debug
-456|bob|2024-05-02T11:00:00|Unknown|PENDING|gpu
-789|carol|2024-05-03T12:00:00|2024-05-03T12:20:00|FAILED|gpu
+123|alice|2024-05-01T10:00:00|2024-05-01T10:05:00|COMPLETED|debug|1|gpu:1
+456|bob|2024-05-02T11:00:00|Unknown|PENDING|gpu|2|gpu:4
+789|carol|2024-05-03T12:00:00|2024-05-03T12:20:00|FAILED|gpu|4|gpu:8
     """.strip()
 
     rows = parse_sacct_output(output, timezone="UTC")
@@ -15,11 +15,15 @@ def test_parse_sacct_output_skips_invalid_rows():
     assert rows[0].job_id == "123"
     assert rows[0].user == "alice"
     assert rows[0].submit_time.isoformat() == "2024-05-01T10:00:00+00:00"
+    assert rows[0].nodes == 1
+    assert rows[0].alloc_gres == "gpu:1"
     assert rows[1].job_id == "789"
+    assert rows[1].nodes == 4
+    assert rows[1].alloc_gres == "gpu:8"
 
 
 def test_parse_sacct_output_warns_on_bad_timestamp(caplog):
-    bad_output = "123|alice|not-a-time|2024-05-01T10:05:00|COMPLETED|debug"
+    bad_output = "123|alice|not-a-time|2024-05-01T10:05:00|COMPLETED|debug|1|gpu:1"
     with caplog.at_level("WARNING"):
         rows = parse_sacct_output(bad_output, timezone="UTC")
     assert rows == []


### PR DESCRIPTION
## Summary
- add a `--job-type` CLI option and propagate the selection into file naming tokens
- extend sacct parsing and job processing to capture node/GRES data, derive job types, and write them to CSV output
- update documentation and tests to cover the new job-type functionality

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68e945b136988325ab26e76c916a3d6c