### PR TITLE
Include job type filter in histogram title

### DIFF
--- a/src/slurm_waiting_times/cli.py
+++ b/src/slurm_waiting_times/cli.py
@@ -153,11 +153,14 @@ def _title(
     users: Sequence[str] | None,
     partitions: Sequence[str] | None,
     include_steps: bool,
+    job_type: str | None,
 ) -> str:
     user_summary = ",".join(users) if users else "all users"
     partition_summary = ",".join(partitions) if partitions else "all partitions"
     steps_summary = "steps included" if include_steps else None
     details = [user_summary, partition_summary]
+    if job_type:
+        details.append(job_type)
     if steps_summary:
         details.append(steps_summary)
     return (
@@ -275,6 +278,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             users=users,
             partitions=partitions,
             include_steps=args.include_steps,
+            job_type=args.job_type,
         ),
     )
     fig.savefig(histogram_path(prefix))

--- a/tests/test_cli_tokens.py
+++ b/tests/test_cli_tokens.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from slurm_waiting_times.cli import _args_tokens
+from slurm_waiting_times.cli import _args_tokens, _title
 
 
 def test_args_tokens_include_end_token_when_not_explicitly_supplied():
@@ -38,3 +38,16 @@ def test_args_tokens_include_job_type_when_requested():
     )
 
     assert "jobtype=multi-node" in tokens
+
+
+def test_title_includes_job_type_when_requested():
+    title = _title(
+        start=datetime(2025, 3, 1),
+        end=datetime(2025, 3, 31),
+        users=None,
+        partitions=None,
+        include_steps=False,
+        job_type="1-gpu",
+    )
+
+    assert "(all users; all partitions; 1-gpu)" in title


### PR DESCRIPTION
## Summary
- include the selected job type in the histogram title when the CLI filter is used
- cover the new title behaviour with a unit test to prevent regressions

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68e94fedb1ec83258e781ddd8aacfdab