### PR TITLE
Add runtime filtering for job durations

### DIFF
--- a/src/slurm_waiting_times/models.py
+++ b/src/slurm_waiting_times/models.py
@@ -16,6 +16,7 @@ class SacctRow:
     partition: str
     nodes: int | None
     alloc_tres: str | None
+    elapsed_seconds: float | None
 
     @property
     def alloc_gres(self) -> str | None:  # pragma: no cover - compatibility shim

--- a/tests/test_cli_tokens.py
+++ b/tests/test_cli_tokens.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 
-from slurm_waiting_times.cli import _args_tokens, _title
+import pytest
+
+from slurm_waiting_times.cli import CliError, _args_tokens, _parse_runtime_filters, _title
 
 
 def test_args_tokens_include_end_token_when_not_explicitly_supplied():
@@ -16,6 +18,7 @@ def test_args_tokens_include_end_token_when_not_explicitly_supplied():
         bin_seconds=False,
         max_wait_hours=None,
         job_type=None,
+        runtime_filters=None,
     )
 
     assert tokens[0] == "start=2025-03-01"
@@ -35,6 +38,7 @@ def test_args_tokens_include_job_type_when_requested():
         bin_seconds=False,
         max_wait_hours=None,
         job_type="multi-node",
+        runtime_filters=None,
     )
 
     assert "jobtype=multi-node" in tokens
@@ -51,3 +55,45 @@ def test_title_includes_job_type_when_requested():
     )
 
     assert "(all users; all partitions; 1-gpu)" in title
+
+
+def test_args_tokens_include_runtime_filters():
+    tokens = _args_tokens(
+        start_supplied=False,
+        start_value=datetime(2025, 3, 1),
+        end_value=datetime(2025, 3, 31),
+        users=None,
+        partitions=None,
+        include_steps=False,
+        tz=None,
+        bins=None,
+        bin_seconds=False,
+        max_wait_hours=None,
+        job_type=None,
+        runtime_filters=[">01:00:00", "01:00:00-02:00:00"],
+    )
+
+    assert "runtime=>01:00:00" in tokens
+    assert "runtime=01:00:00-02:00:00" in tokens
+
+
+def test_parse_runtime_filters_supports_comparisons_and_ranges():
+    filters = _parse_runtime_filters([">=00:30:00", "<02:00:00"])
+
+    assert len(filters) == 2
+    assert all(f.matches(3600) for f in filters)
+    assert not all(f.matches(1200) for f in filters)
+    assert not all(f.matches(7200) for f in filters)
+
+
+def test_parse_runtime_filters_supports_words():
+    filters = _parse_runtime_filters(["shorter:01:00:00", "longer:00:10:00"])
+
+    assert len(filters) == 2
+    assert all(f.matches(1800) for f in filters)
+    assert not all(f.matches(30) for f in filters)
+
+
+def test_parse_runtime_filters_rejects_invalid_values():
+    with pytest.raises(CliError):
+        _parse_runtime_filters(["invalid"])

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -29,6 +29,7 @@ def make_record(wait_minutes: float) -> JobRecord:
         partition="gpu",
         nodes=1,
         alloc_tres=None,
+        elapsed_seconds=wait_seconds,
         wait_seconds=wait_seconds,
     )
 

--- a/tests/test_sacct.py
+++ b/tests/test_sacct.py
@@ -5,9 +5,9 @@ from slurm_waiting_times.sacct import build_sacct_command, parse_sacct_output
 
 def test_parse_sacct_output_skips_invalid_rows():
     output = """
-123|alice|2024-05-01T10:00:00|2024-05-01T10:05:00|COMPLETED|debug|1|cpu=4,mem=8G,node=1,gres/gpu=1
-456|bob|2024-05-02T11:00:00|Unknown|PENDING|gpu|2|cpu=8,mem=16G,node=1,gres/gpu=4
-789|carol|2024-05-03T12:00:00|2024-05-03T12:20:00|FAILED|gpu|4|cpu=32,mem=64G,node=2,gres/gpu=8
+123|alice|2024-05-01T10:00:00|2024-05-01T10:05:00|COMPLETED|debug|1|cpu=4,mem=8G,node=1,gres/gpu=1|00:30:00
+456|bob|2024-05-02T11:00:00|Unknown|PENDING|gpu|2|cpu=8,mem=16G,node=1,gres/gpu=4|00:45:00
+789|carol|2024-05-03T12:00:00|2024-05-03T12:20:00|FAILED|gpu|4|cpu=32,mem=64G,node=2,gres/gpu=8|1-01:00:00
     """.strip()
 
     rows = parse_sacct_output(output, timezone="UTC")
@@ -17,13 +17,17 @@ def test_parse_sacct_output_skips_invalid_rows():
     assert rows[0].submit_time.isoformat() == "2024-05-01T10:00:00+00:00"
     assert rows[0].nodes == 1
     assert rows[0].alloc_tres == "cpu=4,mem=8G,node=1,gres/gpu=1"
+    assert rows[0].elapsed_seconds == 1800
     assert rows[1].job_id == "789"
     assert rows[1].nodes == 4
     assert rows[1].alloc_tres == "cpu=32,mem=64G,node=2,gres/gpu=8"
+    assert rows[1].elapsed_seconds == ((1 * 24 + 1) * 3600)
 
 
 def test_parse_sacct_output_warns_on_bad_timestamp(caplog):
-    bad_output = "123|alice|not-a-time|2024-05-01T10:05:00|COMPLETED|debug|1|cpu=1,gres/gpu=1"
+    bad_output = (
+        "123|alice|not-a-time|2024-05-01T10:05:00|COMPLETED|debug|1|cpu=1,gres/gpu=1|00:10:00"
+    )
     with caplog.at_level("WARNING"):
         rows = parse_sacct_output(bad_output, timezone="UTC")
     assert rows == []

--- a/tests/test_time_utils.py
+++ b/tests/test_time_utils.py
@@ -8,6 +8,7 @@ from slurm_waiting_times.time_utils import (
     freedman_diaconis_bins,
     parse_datetime,
     parse_cli_datetime_window,
+    parse_duration_to_seconds,
 )
 
 
@@ -90,3 +91,21 @@ def test_parse_cli_datetime_window_invalid_month():
 
     with pytest.raises(ValueError):
         parse_cli_datetime_window("2025-13", None, default_start, default_end, tz)
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("00:00:30", 30),
+        ("01:02:03", (1 * 3600) + (2 * 60) + 3),
+        ("2-03:00:00", (2 * 24 + 3) * 3600),
+    ],
+)
+def test_parse_duration_to_seconds_valid(value, expected):
+    assert parse_duration_to_seconds(value) == expected
+
+
+@pytest.mark.parametrize("value", ["", "1:60:00", "not-a-duration"])
+def test_parse_duration_to_seconds_invalid(value):
+    with pytest.raises(ValueError):
+        parse_duration_to_seconds(value)


### PR DESCRIPTION
## Summary
- add a --runtime CLI option that accepts comparisons, ranges, and shorter/longer aliases for elapsed runtimes
- parse the sacct Elapsed column into seconds and propagate it through JobRecord for filtering
- cover runtime parsing and filtering with new utility functions and expanded unit tests

## Testing
- PYTHONPATH=src pytest


------
https://chatgpt.com/codex/tasks/task_e_68e9579700248325b95705c79bf950f4