### PR TITLE
Add Slurm job type filtering for batch vs interactive jobs

### DIFF
--- a/src/slurm_waiting_times/cli.py
+++ b/src/slurm_waiting_times/cli.py
@@ -55,6 +55,11 @@ def parse_arguments(argv: Sequence[str] | None = None) -> argparse.Namespace:
         help="Restrict results to a specific job type derived from sacct metadata.",
     )
     parser.add_argument(
+        "--slurm-job-type",
+        choices=["batch", "interactive"],
+        help="Restrict results to batch or interactive Slurm submissions.",
+    )
+    parser.add_argument(
         "--include-steps",
         action="store_true",
         help="Include job steps such as .batch and .extern entries.",
@@ -215,6 +220,7 @@ def _args_tokens(
     bin_seconds: bool,
     max_wait_hours: float | None,
     job_type: str | None,
+    slurm_job_type: str | None,
     runtime_filters: Sequence[str] | None,
 ) -> list[str]:
     tokens: list[str] = []
@@ -231,6 +237,8 @@ def _args_tokens(
         tokens.append("steps")
     if job_type:
         tokens.append(f"jobtype={job_type}")
+    if slurm_job_type:
+        tokens.append(f"slurmtype={slurm_job_type}")
     # Timezone is intentionally omitted from the filename prefix for clarity.
     if bins is not None:
         tokens.append(f"bins={bins}")
@@ -251,6 +259,7 @@ def _title(
     partitions: Sequence[str] | None,
     include_steps: bool,
     job_type: str | None,
+    slurm_job_type: str | None,
 ) -> str:
     user_summary = ",".join(users) if users else "all users"
     partition_summary = ",".join(partitions) if partitions else "all partitions"
@@ -258,6 +267,8 @@ def _title(
     details = [user_summary, partition_summary]
     if job_type:
         details.append(job_type)
+    if slurm_job_type:
+        details.append(slurm_job_type)
     if steps_summary:
         details.append(steps_summary)
     return (
@@ -334,6 +345,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         user_filters=users,
         partition_filters=partitions,
         job_type=args.job_type,
+        slurm_job_type=args.slurm_job_type,
         max_wait_hours=max_wait,
         runtime_filters=runtime_constraints,
     )
@@ -361,6 +373,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         bin_seconds=args.bin_seconds,
         max_wait_hours=max_wait,
         job_type=args.job_type,
+        slurm_job_type=args.slurm_job_type,
         runtime_filters=args.runtime,
     )
     prefix = build_prefix(now, tokens)
@@ -379,6 +392,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             partitions=partitions,
             include_steps=args.include_steps,
             job_type=args.job_type,
+            slurm_job_type=args.slurm_job_type,
         ),
     )
     fig.savefig(histogram_path(prefix))

--- a/src/slurm_waiting_times/models.py
+++ b/src/slurm_waiting_times/models.py
@@ -9,6 +9,9 @@ class SacctRow:
     """Representation of a row emitted by ``sacct``."""
 
     job_id: str
+    job_id_raw: str | None
+    job_name: str | None
+    submit_line: str | None
     user: str
     submit_time: datetime
     start_time: datetime
@@ -35,3 +38,4 @@ class JobRecord(SacctRow):
 
     wait_seconds: float
     job_type: str | None = None
+    slurm_job_type: str | None = None

--- a/tests/test_cli_tokens.py
+++ b/tests/test_cli_tokens.py
@@ -18,6 +18,7 @@ def test_args_tokens_include_end_token_when_not_explicitly_supplied():
         bin_seconds=False,
         max_wait_hours=None,
         job_type=None,
+        slurm_job_type=None,
         runtime_filters=None,
     )
 
@@ -38,6 +39,7 @@ def test_args_tokens_include_job_type_when_requested():
         bin_seconds=False,
         max_wait_hours=None,
         job_type="multi-node",
+        slurm_job_type=None,
         runtime_filters=None,
     )
 
@@ -52,9 +54,44 @@ def test_title_includes_job_type_when_requested():
         partitions=None,
         include_steps=False,
         job_type="1-gpu",
+        slurm_job_type=None,
     )
 
     assert "(all users; all partitions; 1-gpu)" in title
+
+
+def test_title_includes_slurm_job_type_when_requested():
+    title = _title(
+        start=datetime(2025, 3, 1),
+        end=datetime(2025, 3, 31),
+        users=None,
+        partitions=None,
+        include_steps=False,
+        job_type=None,
+        slurm_job_type="interactive",
+    )
+
+    assert "(all users; all partitions; interactive)" in title
+
+
+def test_args_tokens_include_slurm_job_type_when_requested():
+    tokens = _args_tokens(
+        start_supplied=False,
+        start_value=datetime(2025, 3, 1),
+        end_value=datetime(2025, 3, 31),
+        users=None,
+        partitions=None,
+        include_steps=False,
+        tz=None,
+        bins=None,
+        bin_seconds=False,
+        max_wait_hours=None,
+        job_type=None,
+        slurm_job_type="batch",
+        runtime_filters=None,
+    )
+
+    assert "slurmtype=batch" in tokens
 
 
 def test_args_tokens_include_runtime_filters():
@@ -70,6 +107,7 @@ def test_args_tokens_include_runtime_filters():
         bin_seconds=False,
         max_wait_hours=None,
         job_type=None,
+        slurm_job_type=None,
         runtime_filters=[">01:00:00", "01:00:00-02:00:00"],
     )
 

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -22,6 +22,9 @@ def make_record(wait_minutes: float) -> JobRecord:
     wait_seconds = (start - submit).total_seconds()
     return JobRecord(
         job_id="1",
+        job_id_raw="1",
+        job_name=None,
+        submit_line=None,
         user="alice",
         submit_time=submit,
         start_time=start,
@@ -31,6 +34,8 @@ def make_record(wait_minutes: float) -> JobRecord:
         alloc_tres=None,
         elapsed_seconds=wait_seconds,
         wait_seconds=wait_seconds,
+        job_type=None,
+        slurm_job_type=None,
     )
 
 

--- a/tests/test_sacct.py
+++ b/tests/test_sacct.py
@@ -4,15 +4,20 @@ from slurm_waiting_times.sacct import build_sacct_command, parse_sacct_output
 
 
 def test_parse_sacct_output_skips_invalid_rows():
-    output = """
-123|alice|2024-05-01T10:00:00|2024-05-01T10:05:00|COMPLETED|debug|1|cpu=4,mem=8G,node=1,gres/gpu=1|00:30:00
-456|bob|2024-05-02T11:00:00|Unknown|PENDING|gpu|2|cpu=8,mem=16G,node=1,gres/gpu=4|00:45:00
-789|carol|2024-05-03T12:00:00|2024-05-03T12:20:00|FAILED|gpu|4|cpu=32,mem=64G,node=2,gres/gpu=8|1-01:00:00
-    """.strip()
+    output = "\n".join(
+        [
+            "123|123|job-a|sbatch job-a.sh|alice|2024-05-01T10:00:00|2024-05-01T10:05:00|COMPLETED|debug|1|cpu=4,mem=8G,node=1,gres/gpu=1|00:30:00",
+            "456|456|job-b|srun --pty bash|bob|2024-05-02T11:00:00|Unknown|PENDING|gpu|2|cpu=8,mem=16G,node=1,gres/gpu=4|00:45:00",
+            "789|789|job-c||carol|2024-05-03T12:00:00|2024-05-03T12:20:00|FAILED|gpu|4|cpu=32,mem=64G,node=2,gres/gpu=8|1-01:00:00",
+        ]
+    )
 
     rows = parse_sacct_output(output, timezone="UTC")
     assert len(rows) == 2
     assert rows[0].job_id == "123"
+    assert rows[0].job_id_raw == "123"
+    assert rows[0].job_name == "job-a"
+    assert rows[0].submit_line == "sbatch job-a.sh"
     assert rows[0].user == "alice"
     assert rows[0].submit_time.isoformat() == "2024-05-01T10:00:00+00:00"
     assert rows[0].nodes == 1
@@ -26,7 +31,7 @@ def test_parse_sacct_output_skips_invalid_rows():
 
 def test_parse_sacct_output_warns_on_bad_timestamp(caplog):
     bad_output = (
-        "123|alice|not-a-time|2024-05-01T10:05:00|COMPLETED|debug|1|cpu=1,gres/gpu=1|00:10:00"
+        "123|123|job|sbatch script.sh|alice|not-a-time|2024-05-01T10:05:00|COMPLETED|debug|1|cpu=1,gres/gpu=1|00:10:00"
     )
     with caplog.at_level("WARNING"):
         rows = parse_sacct_output(bad_output, timezone="UTC")


### PR DESCRIPTION
## Summary
- add a --slurm-job-type CLI flag and surface the selection in output metadata
- parse sacct JobIDRaw, JobName, and SubmitLine fields to infer Slurm batch vs interactive submissions
- extend filtering logic and unit tests to cover the new classification behaviour

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68e9635aefa88325a06d58350ae3ad12